### PR TITLE
remove --filesystem=xdg-config/kdeglobals:ro

### DIFF
--- a/org.pyzo.pyzo.json
+++ b/org.pyzo.pyzo.json
@@ -11,7 +11,6 @@
     "--device=dri",
     "--socket=wayland",
     "--filesystem=host",
-    "--filesystem=xdg-config/kdeglobals:ro",
     "--talk-name=com.canonical.AppMenu.Registrar",
     "--talk-name=com.canonical.AppMenu.Registrar.*"
   ],


### PR DESCRIPTION
not needed since KDE runtime 5.12